### PR TITLE
バージョン系ドメインオブジェクトを実装

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.php]
+indent_size = 4

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/console": ">=2.0",
         "composer/semver": "^1.4",
         "czproject/git-php": "^3.16",
-        "howyi/evi": "^1.0"
+        "howyi/evi": "^1.0",
+        "myclabs/php-enum": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Domain/Version/ReleaseType.php
+++ b/src/Domain/Version/ReleaseType.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * ReleaseType
+ */
+final class ReleaseType extends Enum
+{
+    /**
+     * @var string
+     */
+    public const MAJOR = 'major';
+
+    /**
+     * @var string
+     */
+    public const MINOR = 'minor';
+
+    /**
+     * @var string
+     */
+    public const PATCH = 'patch';
+}

--- a/src/Domain/Version/Version.php
+++ b/src/Domain/Version/Version.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+/**
+ * Version
+ */
+class Version
+{
+    /**
+     * @var int
+     */
+    private $major;
+
+    /**
+     * @var int
+     */
+    private $minor;
+
+    /**
+     * @var int
+     */
+    private $patch;
+
+    /**
+     * @var bool
+     */
+    private $isReleased;
+
+    /**
+     * @param int  $major
+     * @param int  $minor
+     * @param int  $patch
+     * @param bool $isReleased
+     */
+    private function __construct(int $major, int $minor, int $patch, bool $isReleased)
+    {
+        $this->major = $major;
+        $this->minor = $minor;
+        $this->patch = $patch;
+        $this->isReleased = $isReleased;
+    }
+
+    /**
+     * リリース済みバージョンを生成する
+     *
+     * @param int  $major
+     * @param int  $minor
+     * @param int  $patch
+     * @return Version
+     */
+    public static function released(int $major, int $minor, int $patch): Version
+    {
+        return new self($major, $minor, $patch, true);
+    }
+
+    /**
+     * 開発中バージョンを生成する
+     *
+     * @param int  $major
+     * @param int  $minor
+     * @param int  $patch
+     * @return Version
+     */
+    public static function wip(int $major, int $minor, int $patch): Version
+    {
+        return new self($major, $minor, $patch, false);
+    }
+
+    /**
+     * このバージョンがリリース済みかを返す
+     *
+     * @return bool
+     */
+    public function isReleased(): bool
+    {
+        return $this->isReleased;
+    }
+
+    /**
+     * このバージョンが開発中かを返す
+     *
+     * @return bool
+     */
+    public function isWip(): bool
+    {
+        return false === $this->isReleased;
+    }
+
+    /**
+     * リリース種別に対応したバージョン番号をインクリメントした新しいバージョンを返す
+     *
+     * インクリメントされた新しいバージョンは常に「開発中」となる
+     *
+     * @param ReleaseType $releaseType
+     * @throws \LogicException
+     * @return Version
+     */
+    public function increment(ReleaseType $releaseType): Version
+    {
+        switch ($releaseType->getValue()) {
+            case ReleaseType::MAJOR:
+                return new Version($this->major + 1, 0, 0, false);
+                break;
+            case ReleaseType::MINOR:
+                return new Version($this->major, $this->minor + 1, 0, false);
+                break;
+            case ReleaseType::PATCH:
+                return new Version($this->major, $this->minor, $this->patch + 1, false);
+                break;
+            default:
+                // 本来到達し得ない
+                throw new \LogicException(sprintf('対応していないリリース種別を渡された: %s', $releaseType->getValue()));
+                break;
+        }
+    }
+
+    /**
+     * このバージョンの文字列表現を返す
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        // TODO: 844196 設定ファイルを参照するようにする
+        $versionPrefix = '';
+        return sprintf('%s%d.%d.%d', $versionPrefix, $this->major, $this->minor, $this->patch);
+    }
+
+    /**
+     * このバージョンのリリースブランチ名を返す
+     *
+     * @return string
+     */
+    public function toReleaseBranchName(): string
+    {
+        // TODO: 844196 設定ファイルを参照するようにする
+        $branchPrefix = 'release/';
+        $versionPrefix = '';
+        return sprintf('%s%s%s', $branchPrefix, $versionPrefix, $this->toString());
+    }
+}

--- a/src/Domain/Version/VersionAscIterator.php
+++ b/src/Domain/Version/VersionAscIterator.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+use Composer\Semver\Comparator;
+
+/**
+ * VersionAscIterator
+ */
+class VersionAscIterator implements \IteratorAggregate
+{
+    /**
+     * @var Version[]
+     */
+    private $versions;
+
+    /**
+     * @param Version[] $versions
+     */
+    public function __construct(Version ...$versions)
+    {
+        $compare = function (Version $x, Version $y): int {
+            $xstr = $x->toString();
+            $ystr = $y->toString();
+            if (Comparator::equalTo($xstr, $ystr)) {
+                return 0;
+            }
+            return Comparator::greaterThan($xstr, $ystr) ? 1 : -1;
+        };
+        usort($versions, $compare);
+        $this->versions = $versions;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->versions as $version) {
+            yield $version;
+        }
+    }
+}

--- a/src/Domain/Version/VersionCollection.php
+++ b/src/Domain/Version/VersionCollection.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+/**
+ * VersionCollection
+ */
+class VersionCollection implements \IteratorAggregate
+{
+    /**
+     * @var Version[]
+     */
+    private $container = [];
+
+    /**
+     * @param Version[] $container
+     */
+    public function __construct(Version ...$versions)
+    {
+        $this->container = $versions;
+    }
+
+    /**
+     * コレクション同士を結合した新しいコレクションを返す
+     *
+     * @return VersionCollection
+     */
+    public static function concat(VersionCollection ...$collections): VersionCollection
+    {
+        $versions = [];
+        foreach ($collections as $collection) {
+            foreach ($collection->container as $version) {
+                $versions[] = $version;
+            }
+        }
+        return new self(...$versions);
+    }
+
+    /**
+     * バージョンを格納する
+     *
+     * @param Version $version
+     * @return self
+     */
+    public function push(Version $version): self
+    {
+        $this->container[] = $version;
+        return $this;
+    }
+
+    /**
+     * リリース済みバージョンのみが格納された新しいコレクションを返す
+     *
+     * @return VersionCollection
+     */
+    public function released(): VersionCollection
+    {
+        $isReleased = function (Version $x): bool {
+            return $x->isReleased();
+        };
+        return new self(...array_filter($this->container, $isReleased));
+    }
+
+    /**
+     * 開発中バージョンのみが格納された新しいコレクションを返す
+     *
+     * @return VersionCollection
+     */
+    public function wip(): VersionCollection
+    {
+        $isWip = function (Version $x): bool {
+            return $x->isWip();
+        };
+        return new self(...array_filter($this->container, $isWip));
+    }
+
+    /**
+     * 格納されているバージョンのうち、最新のものを返す
+     *
+     * 何も格納されていない場合はnullを返す
+     *
+     * @return Version|null
+     */
+    public function latest(): ?Version
+    {
+        // array_popは参照渡しを要求するため、一旦変数に格納する
+        $ascSorted = $this->toAscSortedArray();
+        return array_pop($ascSorted);
+    }
+
+    /**
+     * 昇順ソート済み配列として返す
+     *
+     * @return Version[]
+     */
+    public function toAscSortedArray(): array
+    {
+        return iterator_to_array($this->getIterator());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator(): \Traversable
+    {
+        return new VersionAscIterator(...$this->container);
+    }
+}

--- a/tests/Domain/Version/VersionAscIteratorTest.php
+++ b/tests/Domain/Version/VersionAscIteratorTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+use PHPUnit\Framework\TestCase;
+
+class VersionAscIteratorTest extends TestCase
+{
+    public function testAll()
+    {
+        $iterator = new VersionAscIterator(
+            Version::released(1, 0, 1),
+            Version::wip(1, 2, 0),
+            Version::released(1, 1, 1),
+            Version::released(1, 0, 0),
+            Version::wip(1, 1, 2),
+            Version::released(1, 1, 0),
+            Version::wip(2, 0, 0),
+            Version::released(1, 0, 2)
+        );
+
+        $expected = [
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+            Version::released(1, 0, 2),
+            Version::released(1, 1, 0),
+            Version::released(1, 1, 1),
+            Version::wip(1, 1, 2),
+            Version::wip(1, 2, 0),
+            Version::wip(2, 0, 0),
+        ];
+        $actual = iterator_to_array($iterator);
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Domain/Version/VersionCollectionTest.php
+++ b/tests/Domain/Version/VersionCollectionTest.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+use PHPUnit\Framework\TestCase;
+
+class VersionCollectionTest extends TestCase
+{
+    private $versions;
+
+    public function setUp()
+    {
+        $this->versions = new VersionCollection(...[
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 2),
+            Version::wip(1, 1, 0),
+            Version::released(1, 0, 1),
+        ]);
+    }
+
+    public function testConcat()
+    {
+        $a = new VersionCollection(...[
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+        ]);
+        $b = new VersionCollection(...[
+            Version::wip(1, 0, 2),
+            Version::wip(2, 0, 0),
+        ]);
+
+        $expected = [
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+            Version::wip(1, 0, 2),
+            Version::wip(2, 0, 0),
+        ];
+        $actual = VersionCollection::concat($a, $b)->toAscSortedArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testPush()
+    {
+        $expected = [
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+            Version::released(1, 0, 2),
+            Version::wip(1, 1, 0),
+            Version::wip(2, 0, 0),
+        ];
+        $actual = $this->versions->push(Version::wip(2, 0, 0))->toAscSortedArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetIterator()
+    {
+        $this->assertInstanceOf(VersionAscIterator::class, $this->versions->getIterator());
+    }
+
+    public function testReleased()
+    {
+        $expected = [
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+            Version::released(1, 0, 2),
+        ];
+        $actual = $this->versions->released()->toAscSortedArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testWip()
+    {
+        $expected = [Version::wip(1, 1, 0)];
+        $actual = $this->versions->wip()->toAscSOrtedArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testLatest()
+    {
+        $expected = Version::wip(1, 1, 0);
+        $actual = $this->versions->latest();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testToAscSortedArray()
+    {
+        $expected = [
+            Version::released(1, 0, 0),
+            Version::released(1, 0, 1),
+            Version::released(1, 0, 2),
+            Version::wip(1, 1, 0),
+        ];
+        $actual = $this->versions->toAscSortedArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Domain/Version/VersionTest.php
+++ b/tests/Domain/Version/VersionTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Howyi\Cra\Domain\Version;
+
+use PHPUnit\Framework\TestCase;
+
+class VersionTest extends TestCase
+{
+    public function testReleased()
+    {
+        $version = Version::released(1, 2, 3);
+        $this->assertTrue($version->isReleased());
+        $this->assertFalse($version->isWip());
+    }
+
+    public function testWip()
+    {
+        $version = Version::wip(1, 2, 3);
+        $this->assertFalse($version->isReleased());
+        $this->assertTrue($version->isWip());
+    }
+
+    public function releaseTypeDataProvider()
+    {
+        return [
+            'Minor' => [ReleaseType::MINOR(), Version::released(1, 2, 3), Version::wip(1, 3, 0)],
+            'Major' => [ReleaseType::MAJOR(), Version::released(1, 2, 3), Version::wip(2, 0, 0)],
+            'Patch' => [ReleaseType::PATCH(), Version::released(1, 2, 3), Version::wip(1, 2, 4)],
+        ];
+    }
+
+    /**
+     * @dataProvider releaseTypeDataProvider
+     */
+    public function testIncrement($releaseType, $version, $expected)
+    {
+        $this->assertEquals($expected, $version->increment($releaseType));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage 対応していないリリース種別を渡された: test
+     */
+    public function testIncrementGivenInvalidReleaseType()
+    {
+        // 普通にnewするとMyCLabs\Enum\Enumのチェックが走るため、無理やり書き換える
+        $releaseType = ReleaseType::MAJOR();
+        \Closure::bind(function () {
+            $this->value = 'test';
+        }, $releaseType, ReleaseType::class)->__invoke();
+
+        Version::released(1, 2, 3)->increment($releaseType);
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('1.2.3', Version::released(1, 2, 3)->toString());
+    }
+
+    public function testToReleaseBranchName()
+    {
+        $this->assertSame('release/1.2.3', Version::released(1, 2, 3)->toReleaseBranchName());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
* `ReleaseType`
* `Version`
* `VersionCollection`
* `VersionAscIterator`

---

* `myclabs/php-enum` を依存関係に追加
* PHPUnitの設定ファイルを追加
* EditorConfigの設定ファイルを追加